### PR TITLE
feat: add css styling property for svg size

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ document.getElementById('avatar').innerHTML = svg
 
 <h2>Configuration options</h2>
 
-|Name|Type|Description|Default|
-|---|---|---|---|
-|`size`|`number`|Avatar size in pixels|`150`|
-|`round`|`boolean`|Use round or rectangle shape|`true`|
-|`blackout`|`boolean`|Use blackout for right side of an avatar|`true`|
-|`avatarColors`|`string[]`|Palette for avatar colors|`['#d7b89c', '#b18272','#ec8a90','#a1Ac88','#99c9bd','#50c8c6']`|
-|`backgroundColors`|`string[]`|Palette for background colors|`['#fcf7d1', '#ece2e1','#e4e3cd','#c4ddd6','#b5f4bc']`|
+|Name| Type               | Description                           | Default                                                          |
+|---|--------------------|---------------------------------------|------------------------------------------------------------------|
+|`size`| `number or string` | Avatar size in pixels or css property | `150 or '75%'`                                                   |
+|`round`| `boolean`          | Use round or rectangle shape          | `true`                                                           |
+|`blackout`| `boolean`          | Use blackout for right side of an avatar | `true`                                                           |
+|`avatarColors`| `string[]`         | Palette for avatar colors             | `['#d7b89c', '#b18272','#ec8a90','#a1Ac88','#99c9bd','#50c8c6']` |
+|`backgroundColors`| `string[]`         | Palette for background colors         | `['#fcf7d1', '#ece2e1','#e4e3cd','#c4ddd6','#b5f4bc']`           |
 
 Missing a configuration? [Raise an issue](https://github.com/roma-lukashik/animal-avatar-generator/issues/new?title=New%20configuration:).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { avatarColors as aColors, backgroundColors as bColors } from './palette'
 import { Shape, faces, ears, muzzles, eyes, brows, patterns, hairs, emptyShape } from './shapes'
 
 export type AvatarOptions = {
-  size?: number;
+  size?: number | string;
   avatarColors?: string[];
   backgroundColors?: string[];
   blackout?: boolean;

--- a/src/utils/svg.ts
+++ b/src/utils/svg.ts
@@ -1,4 +1,4 @@
-export const createSvg = (size: number, ...children: string[]) => `
+export const createSvg = (size: number | string, ...children: string[]) => `
   <svg
     xmlns="http://www.w3.org/2000/svg"
     version="1.1"


### PR DESCRIPTION
Adding possibility to add a css style for the size property of the svg, for example to match parent element height. Raw pixel input as number is still possible